### PR TITLE
Update module name

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,18 @@
+# Gitleaks configuration to allow fake test credentials
+[[rules]]
+  id = "aws-access-key"
+  description = "AWS Access Key ID"
+  regex = '''AKIA[0-9A-Z]{16}'''
+  
+  [[rules.allowlist]]
+    regex = '''fake'''
+    description = "Allow fake test credentials"
+
+[[rules]]
+  id = "aws-secret-key"
+  description = "AWS Secret Access Key"
+  regex = '''[0-9a-zA-Z/+]{40}'''
+  
+  [[rules.allowlist]]
+    regex = '''fake'''
+    description = "Allow fake test credentials"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Terraform AWS Secure S3 Website with CloudFront
+# Terraform AWS Static Website
 
-[![Terraform Validation](https://github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront/actions/workflows/terraform-validation.yml/badge.svg)](https://github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront/actions/workflows/terraform-validation.yml)
+[![Terraform Validation](https://github.com/mikmorley/terraform-aws-static-website/actions/workflows/terraform-validation.yml/badge.svg)](https://github.com/mikmorley/terraform-aws-static-website/actions/workflows/terraform-validation.yml)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Terraform](https://img.shields.io/badge/Terraform-%E2%89%A5%201.0-blue.svg)](https://terraform.io/)
 [![AWS Provider](https://img.shields.io/badge/AWS%20Provider-%E2%89%A5%205.0-orange.svg)](https://registry.terraform.io/providers/hashicorp/aws/latest)
@@ -36,7 +36,7 @@ A production-ready Terraform module that creates a secure, scalable static websi
 
 ```hcl
 module "secure_website" {
-  source = "github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront"
+  source = "mikmorley/static-website/aws"
 
   name        = "my-website"
   environment = "Production"
@@ -61,7 +61,7 @@ This module creates the following AWS resources:
 
 ```hcl
 module "website" {
-  source = "github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront"
+  source = "mikmorley/static-website/aws"
 
   name        = "company-website"
   environment = "Production"
@@ -77,7 +77,7 @@ output "website_url" {
 
 ```hcl
 module "website" {
-  source = "github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront"
+  source = "mikmorley/static-website/aws"
 
   name        = "company-website"
   environment = "Production"
@@ -92,7 +92,7 @@ module "website" {
 
 ```hcl
 module "website" {
-  source = "github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront"
+  source = "mikmorley/static-website/aws"
 
   name           = "company-website"
   s3_bucket_name = "my-existing-bucket"
@@ -211,6 +211,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Support
 
 For questions, issues, or contributions:
-- 🐛 [Report Issues](https://github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront/issues)
-- 📖 [View Documentation](https://github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront)
-- 💡 [Request Features](https://github.com/mikmorley/terraform-aws-secure-s3-website-with-cloudfront/issues)
+- 🐛 [Report Issues](https://github.com/mikmorley/terraform-aws-static-website/issues)
+- 📖 [View Documentation](https://github.com/mikmorley/terraform-aws-static-website)
+- 💡 [Request Features](https://github.com/mikmorley/terraform-aws-static-website/issues)

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,6 +1,6 @@
 # Basic Example
 
-This example demonstrates the basic usage of the `terraform-aws-secure-s3-website-with-cloudfront` module.
+This example demonstrates the basic usage of the `terraform-aws-static-website` module.
 
 ## Usage
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,7 +1,7 @@
-module "secure_s3_website" {
+module "static_website" {
   source = "../../"
 
-  name        = "my-secure-website"
+  name        = "my-static-website"
   environment = "Production"
   region      = "us-east-1"
 

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -1,14 +1,14 @@
 output "website_url" {
   description = "The CloudFront URL for the website"
-  value       = "https://${module.secure_s3_website.cloudfront_url}"
+  value       = "https://${module.static_website.cloudfront_url}"
 }
 
 output "s3_bucket_name" {
   description = "The name of the S3 bucket"
-  value       = module.secure_s3_website.s3_bucket_name
+  value       = module.static_website.s3_bucket_name
 }
 
 output "cloudfront_distribution_id" {
   description = "The CloudFront distribution ID"
-  value       = module.secure_s3_website.cloudfront_distribution_id
+  value       = module.static_website.cloudfront_distribution_id
 }


### PR DESCRIPTION
This pull request updates the module and repository naming from `terraform-aws-secure-s3-website-with-cloudfront` to `terraform-aws-static-website` throughout the codebase and documentation, reflecting a shift in branding and usage. It also adds a Gitleaks configuration to allow fake test credentials for AWS keys in the repository.

**Repository and module renaming:**

* Updated all references in `README.md`, example usage, and documentation links to use the new module name `terraform-aws-static-website` and repository name `mikmorley/terraform-aws-static-website` instead of the previous `terraform-aws-secure-s3-website-with-cloudfront`. This includes badges, documentation URLs, and example code blocks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L39-R39) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R80) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R95) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L214-R216) [[7]](diffhunk://#diff-fe83992f154cc181844b6bf965a0b6aba367c7b498a3a0db43b5b212d041531bL3-R3)

* Updated example Terraform files in `examples/basic/` to use the new module name and output references (`static_website` instead of `secure_s3_website`). [[1]](diffhunk://#diff-6e45d26e502f88302f69c4c196babd8939186d9cd298f94caca283c128a2d186L1-R4) [[2]](diffhunk://#diff-0f9855edd123720486ac5f8b22c27957e4f46ab4caf7d28190f10d1fe534cac6L3-R13)

**Security and compliance:**

* Added a `.gitleaks.toml` configuration to allow fake AWS credentials in test code, preventing false positives in secret scanning while maintaining security for real credentials.